### PR TITLE
Added call to System.gc on scenario switch

### DIFF
--- a/src/com/hms/ewon/ignitionflexydemo/FlexyDemo.java
+++ b/src/com/hms/ewon/ignitionflexydemo/FlexyDemo.java
@@ -261,6 +261,9 @@ public class FlexyDemo {
         // MARK CURRENT SCENARIO
         currentScenario = chosenScenario;
 
+        // FORCE GARBAGE COLLECTION
+        System.gc();
+
         // START NEW SELECTED SCENARIO
         if (chosenScenario >= 0 && chosenScenario < flexyDemoScenarios.size()) {
           FlexyDemoScenario nextRunning = (FlexyDemoScenario) flexyDemoScenarios


### PR DESCRIPTION
Java garbage collection is now called when changing demo scenarios to help reduce problems with memory running out.